### PR TITLE
Removal of visualisation menu

### DIFF
--- a/analysistools.cpp
+++ b/analysistools.cpp
@@ -514,6 +514,9 @@ QString AnalysisTools::Stasis(QString filename, int slot_count, float percentile
           if (spe.end!=spe.start) pval=(100*((spe.end-spe.start)-spe.occurrences))/(spe.end-spe.start);
           else pval=100;
 //          out << "Species: "<<ID << ": " << spe.start << "-"<<spe.end<<" Parent "<<spe.parent<<"  maxsize "<<spe.maxsize<<"  Av size "<<(spe.totalsize/spe.occurrences)<< "  %missing "<<100-pval<< endl;
+
+            //ARTS - compiler warning supression
+            Q_UNUSED(pval);
       }
 
       //Now cull  extinct species without issue
@@ -562,7 +565,10 @@ QString AnalysisTools::Stasis(QString filename, int slot_count, float percentile
          int pval;
          if (spe.end!=spe.start) pval=(100*((spe.end-spe.start)-spe.occurrences))/(spe.end-spe.start);
          else pval=100;
-//         out << "Species: "<<ID << ": " << spe.start << "-"<<spe.end<<" Parent "<<spe.parent<<"  maxsize "<<spe.maxsize<<"  Av size "<<(spe.totalsize/spe.occurrences)<< "  %missing "<<100-pval<<endl;
+//          out << "Species: "<<ID << ": " << spe.start << "-"<<spe.end<<" Parent "<<spe.parent<<"  maxsize "<<spe.maxsize<<"  Av size "<<(spe.totalsize/spe.occurrences)<< "  %missing "<<100-pval<<endl;
+
+            //ARTS - compiler warning supression
+            Q_UNUSED(pval);
      }
 
      //Tree version reordered here, I just create magiclist as a copy of culled list
@@ -1396,4 +1402,23 @@ QString AnalysisTools::DumpData(LogSpecies *root, quint64 min_speciessize, bool 
         return "ERROR - NO PHYLOGENY DATA";
 
     //recurse over species,
+
+    //ARTS - compiler warning supression
+    Q_UNUSED(ID);
+    Q_UNUSED(parent);
+    Q_UNUSED(time_of_first_appearance);
+    Q_UNUSED(time_of_last_appearance);
+    Q_UNUSED(maxsize);
+    Q_UNUSED(generation);
+    Q_UNUSED(sample_genome);
+    Q_UNUSED(size);
+    Q_UNUSED(genomic_diversity);
+    Q_UNUSED(cells_occupied);
+    Q_UNUSED(geographical_range);
+    Q_UNUSED(centroid_range_x);
+    Q_UNUSED(centroid_range_y);
+    Q_UNUSED(mean_fitness);
+    Q_UNUSED(min_env);
+    Q_UNUSED(max_env);
+    Q_UNUSED(mean_env);
 }

--- a/critter.cpp
+++ b/critter.cpp
@@ -33,7 +33,7 @@ Critter::Critter()
 
     //Temporary variable breed tag. Probably better way of doing this but short on time
     int variableBreedAsex = 0;
-
+    Q_UNUSED(variableBreedAsex);
 }
 
 void Critter::initialise(quint64 gen, quint8 *env, int x, int y, int z, quint64 species)

--- a/environmentscene.cpp
+++ b/environmentscene.cpp
@@ -98,6 +98,9 @@ void EnvironmentScene::mouseReleaseEvent ( QGraphicsSceneMouseEvent * event )
     x=(int)position.x();
     y=(int)position.y();
 
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+
     return;
 }
 

--- a/genomecomparison.cpp
+++ b/genomecomparison.cpp
@@ -21,60 +21,51 @@
 #include <QDebug>
 #include <QMessageBox>
 
-/*---------------------------------------------------------------------------//
-    Constructor
-//---------------------------------------------------------------------------*/
-
+//Constructor
 GenomeComparison::GenomeComparison(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::GenomeComparison)
 {
     ui->setupUi(this);
 
-    //---- Set Auto Compare
+    //Set Auto Compare
     autoComparison = true;
 
-    //---- Set Column Colours
-    first32 = QColor(51, 153, 51);
-    last32 = QColor(51, 51, 153);
-    spacerCol = QColor(242,242,242);
-    highlight = QColor(215,206,152);
+    //Set Column Colours
+    first32 = QColor(0, 100,0); // Green
+    last32 = QColor(200, 0, 0); // Red
+    spacerCol = QColor(255,255,255); //White
+    highlight = QColor(127,127,127); //Gray
 
-    //---- Render Genome Tables
+    //Render Genome Tables
     QFont fnt;
     fnt.setPointSize(8);
     fnt.setFamily("Arial");
 
     ui->genomeTableWidget->setFont(fnt);
     ui->genomeTableWidget->setColumnWidth(1,100);
-    ui->genomeTableWidget->setColumnWidth(34,2);
+    ui->genomeTableWidget->setColumnWidth(34,2); // Spacer
     renderGenomesTable();
 
     ui->compareTableWidget->setFont(fnt);
     ui->compareTableWidget->setColumnWidth(1,100);
     ui->compareTableWidget->setColumnWidth(34,2);
 
-    //---- Signal to capture name change
+    //Signal to capture name change
     connect(ui->genomeTableWidget, SIGNAL(cellChanged(int, int)), this, SLOT(updateGenomeName(int, int)));
 
-    //---- Add Button Actions
+    //Add Button Actions
     buttonActions();
     buttonUpdate();
 }
 
-/*---------------------------------------------------------------------------//
-    Destructor
-//---------------------------------------------------------------------------*/
-
+//Destructor
 GenomeComparison::~GenomeComparison()
 {
     delete ui;
 }
 
-/*---------------------------------------------------------------------------//
-    Buttons
-//---------------------------------------------------------------------------*/
-
+//Buttons
 void GenomeComparison::buttonActions()
 {
     connect(ui->compareButton, SIGNAL(pressed()), this, SLOT(compareGenomes()));
@@ -103,10 +94,7 @@ void GenomeComparison::buttonUpdate()
     }
 }
 
-/*---------------------------------------------------------------------------//
-    Tables
-//---------------------------------------------------------------------------*/
-
+//Tables
 bool GenomeComparison::renderGenomesTable(){
     ui->genomeTableWidget->hide();
     ui->genomeTableWidget->clear();
@@ -135,28 +123,28 @@ bool GenomeComparison::renderGenomesTable(){
         }
     }
     ui->genomeTableWidget->setColumnWidth(i,30);
-    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("E.")));
+    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("E")));
     i++;
     ui->genomeTableWidget->setColumnWidth(i,30);
-    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("G.")));
+    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("G")));
     i++;
     ui->genomeTableWidget->setColumnWidth(i,30);
-    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("N.")));
+    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("N")));
     i++;
     ui->genomeTableWidget->setColumnWidth(i,30);
-    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("F.")));
+    ui->genomeTableWidget->setHorizontalHeaderItem(i,new QTableWidgetItem(tr("F")));
 
-    //----- Add rows if genomeList.count() != 0
+    //Add rows if genomeList.count() != 0
     if (!genomeList.empty()) {
         for(int row=0; row<genomeList.count(); row++){
-            //---- Add to table
+            //Add to table
             if (autoComparison == true && row!=0) {
-                //---- Do comparison with last genome...
+                //Do comparison with last genome...
                 QMap<QString,QString> genomeListMapA = genomeList[row-1];
                 QMap<QString,QString> genomeListMapB = genomeList[row];
                 QString compareMask;
 
-                //---- Create Masks
+                //Create Masks
                 for (int i=0; i<64; i++)
                 {
                     if (genomeListMapA["genome"].at(i) == genomeListMapB["genome"].at(i)) {
@@ -184,7 +172,7 @@ bool GenomeComparison::renderGenomesTable(){
                             ui->genomeTableWidget,
                             compareMask);
             } else {
-                //---- No compare, just add...
+                //No compare, just add...
                 insertRow(
                             row,
                             genomeList[row]["name"],
@@ -281,14 +269,14 @@ void GenomeComparison::insertRow(
         }
 
         if (comparisonMask.length() !=0 && comparisonMask.at(i) == QChar(49)) {
-            //---- There is a mask, formate...
+            //There is a mask, formate...
             table->item(row, col)->setBackground(QBrush(highlight));
         }
 
         col++;
     }
 
-    //---- Add environment as cell background
+    //Add environment as cell background
     QTableWidgetItem *newItem = new QTableWidgetItem(tr(""));
     newItem->setTextAlignment(Qt:: AlignCenter);
     newItem->setFlags(Qt::ItemIsEnabled);
@@ -297,7 +285,7 @@ void GenomeComparison::insertRow(
     table->item(row, col)->setBackgroundColor(envColour);    
     col++;
 
-    //---- Add genome colour as cell background
+    //Add genome colour as cell background
     newItem = new QTableWidgetItem(tr(""));
     newItem->setTextAlignment(Qt:: AlignCenter);
     newItem->setFlags(Qt::ItemIsEnabled);
@@ -306,7 +294,7 @@ void GenomeComparison::insertRow(
     table->item(row, col)->setBackgroundColor(genomeColour);
     col++;
 
-    //---- Add non coded colour as cell background
+    //Add non coded colour as cell background
     newItem = new QTableWidgetItem(tr(""));
     newItem->setTextAlignment(Qt:: AlignCenter);
     newItem->setFlags(Qt::ItemIsEnabled);
@@ -315,7 +303,7 @@ void GenomeComparison::insertRow(
     table->item(row, col)->setBackgroundColor(nonCodeColour);
     col++;
 
-    //---- Add Fitness
+    //Add Fitness
     newItem = new QTableWidgetItem();
     newItem->setTextAlignment(Qt:: AlignCenter);
     newItem->setFlags(Qt::ItemIsEnabled);
@@ -336,24 +324,24 @@ bool GenomeComparison::renderCompareTable() {
     ui->compareTableWidget->setColumnWidth(69,30);
     ui->compareTableWidget->setColumnWidth(70,30);
 
-    //---- Setup
+    //Setup
     if (!compareList.empty()) {
         QMap<QString,QString> genomeListMapA = compareList[0];
         QMap<QString,QString> genomeListMapB = compareList[1];
         QString compareMask;
 
-        //---- Create Masks
+        //Create Masks
         for (int i=0; i<64; i++)
         {
             if (genomeListMapA["genome"].at(i) == genomeListMapB["genome"].at(i)) {
-                //---- Same bit
+                //Same bit
                 compareMask.append("0");
             } else {
                 compareMask.append("1");
             }
         }
 
-        //---- Insert Rows
+        //Insert Rows
         insertRow(
                     0,
                     genomeListMapA["name"],
@@ -392,10 +380,7 @@ bool GenomeComparison::renderCompareTable() {
     return true;
 }
 
-/*---------------------------------------------------------------------------//
-    Table Actions
-//---------------------------------------------------------------------------*/
-
+//Table Actions follow...
 void GenomeComparison::updateGenomeName(int row, int col) {
     if (col == 1) {
         QString newName = ui->genomeTableWidget->item(row, col)->text();
@@ -409,29 +394,29 @@ bool GenomeComparison::addGenomeCritter(Critter critter, quint8 *environment)
     int row = genomeList.count();
     quint32 genome;
 
-    //---- Genome
+    //Start with whole genome
     QString genomeStr;
     for (int j=0; j<64; j++)
-        //---- RJG - if genome bit is 1, number is > 0; else it's zero.
+        //RJG - if genome bit is 1, number is > 0; else it's zero.
         if (tweakers64[63-j] & critter.genome) genomeStr.append("1"); else genomeStr.append("0");
 
-    //---- Genome Colour
-    genome = (quint32)(critter.genome & ((quint64)65536*(quint64)65536-(quint64)1));
+    //Coding Genome Colour
+    genome = (quint32)(critter.genome & ((quint64)65536*(quint64)65536-(quint64)1)); //lower 32 bits
     quint32 genomeB = bitcounts[genome & 2047] * 23;
     genome /=2048;
     quint32 genomeG = bitcounts[genome & 2047] * 23;
     genome /=2048;
     quint32 genomeR = bitcounts[genome] * 25;
 
-    //---- Non coding Colour
-    genome = (quint32)(critter.genome / ((quint64)65536*(quint64)65536));
+    //Non-coding Genome Colour
+    genome = (quint32)(critter.genome / ((quint64)65536*(quint64)65536)); //upper 32 bits
     quint32 nonCodeB = bitcounts[genome & 2047] * 23;
     genome /=2048;
     quint32 nonCodeG = bitcounts[genome & 2047] * 23;
     genome /=2048;
     quint32 nonCodeR = bitcounts[genome] * 25;
 
-    //---- Fitness
+    //Fitness
     int fitness = critter.fitness;
 
     QMap<QString,QString> genomeListMap;
@@ -449,14 +434,14 @@ bool GenomeComparison::addGenomeCritter(Critter critter, quint8 *environment)
     genomeListMap.insert("fitness",QString("%1").arg(fitness));
     genomeList.append(genomeListMap);
 
-    //---- Add to table
+    //Add to table
     if (autoComparison == true && row!=0) {
-        //---- Do comparison with last genome...
+        //Do comparison with last genome...
         QMap<QString,QString> genomeListMapA = genomeList[row-1];
         QMap<QString,QString> genomeListMapB = genomeList[row];
         QString compareMask;
 
-        //---- Create Masks
+        //Create Masks
         for (int i=0; i<64; i++)
         {
             if (genomeListMapA["genome"].at(i) == genomeListMapB["genome"].at(i)) {
@@ -484,7 +469,7 @@ bool GenomeComparison::addGenomeCritter(Critter critter, quint8 *environment)
                     ui->genomeTableWidget,
                     compareMask);
     } else {
-        //---- No compare, just add...
+        //No compare, just add...
         insertRow(
                     row,
                     genomeListMap["name"],
@@ -502,7 +487,7 @@ bool GenomeComparison::addGenomeCritter(Critter critter, quint8 *environment)
                     ui->genomeTableWidget);
     }
 
-    //---- Update Button States
+    //Update Button States
     buttonUpdate();
 
     return true;
@@ -513,13 +498,13 @@ QByteArray GenomeComparison::saveComparison()
     QByteArray outData;
     QDataStream out(&outData,QIODevice::WriteOnly);
 
-    //---- Output setup variable states
+    //Output setup variable states
     out<<autoComparison;
 
-    //---- Output Manual Comparison Table Genome List
+    //Output Manual Comparison Table Genome List
     out<<compareList;
 
-    //---- Output Main Comparison Table Genome List
+    //Output Main Comparison Table Genome List
     out<<genomeList;
 
     return outData;
@@ -529,40 +514,37 @@ bool GenomeComparison::loadComparison(QByteArray inData)
 {
     QDataStream in(&inData,QIODevice::ReadOnly);
 
-    //---- Get setup variable states
+    //Get setup variable states
     in>>autoComparison;
 
-    //---- Reset All Tables
+    //Reset All Tables
     resetTables();
 
-    //---- Get Manual Comparison Table Genome List
+    //Get Manual Comparison Table Genome List
     in>>compareList;
     if (!compareList.empty()) {
         renderCompareTable();
     }
-    //---- Get Main Comparison Table Genome List
+    //Get Main Comparison Table Genome List
     in>>genomeList;
     if (!genomeList.empty()) {
         renderGenomesTable();
     }
 
-    //---- Update Button States
+    //Update Button States
     buttonUpdate();
 
     return true;
 }
 
-/*---------------------------------------------------------------------------//
-    Button Actions
-//---------------------------------------------------------------------------*/
-
+//Button Actions
 bool GenomeComparison::compareGenomes()
 {
-    //---- Are there any checked genomes?
+    //Are there any checked genomes?
     QList<int> checkedList = isGenomeChecked();
     int numChecked = checkedList.count();
 
-    //---- Check that there two genomes checked
+    //Check that there two genomes checked
     if (numChecked == 0) {
         QMessageBox msgBox;
         msgBox.setWindowTitle(tr("Genome Comparison: Error"));
@@ -605,19 +587,19 @@ bool GenomeComparison::resetTables()
 
 bool GenomeComparison::deleteGenome()
 {
-    //---- Are there any checked genomes?
+    //Are there any checked genomes?
     QList<int> checkedList = isGenomeChecked();
     int numChecked = checkedList.count();
 
     if (numChecked == 0) {
-        //---- Nothing Checked
+        //Nothing Checked
         QMessageBox msgBox;
         msgBox.setWindowTitle(tr("Genome Comparison: Error"));
         msgBox.setText(tr("You need to select at least 1 genome from the table to delete."));
         msgBox.exec();
         return false;
     } else {
-        //---- Something Checked, Remove selected from genomeList
+        //Something Checked, Remove selected from genomeList
         for(int i=0;i<numChecked; i++)
         {
             genomeList.removeAt(checkedList[i-i]);
@@ -638,15 +620,12 @@ void GenomeComparison::setAuto(bool toggle)
     if (autoComparison != toggle){
         autoComparison = toggle;
 
-        //---- Reload Genome Table
+        //Reload Genome Table
         renderGenomesTable();
     }
 }
 
-/*---------------------------------------------------------------------------//
-    Tables Functions
-//---------------------------------------------------------------------------*/
-
+//Tables Functions
 QList<int> GenomeComparison::isGenomeChecked()
 {
     QList<int> checkedList;
@@ -654,7 +633,7 @@ QList<int> GenomeComparison::isGenomeChecked()
     for (int i=0; i<genomeList.count(); i++)
     {
         if (ui->genomeTableWidget->item(i,0)->checkState() == Qt::Checked) {
-            //---- Yes, add to list
+            //Yes, add to list
             checkedList.append(i);
         }
     }
@@ -662,10 +641,8 @@ QList<int> GenomeComparison::isGenomeChecked()
     return checkedList;
 }
 
-/*---------------------------------------------------------------------------//
-    RJG - Access Functions
-//---------------------------------------------------------------------------*/
 
+//RJG - Access Functions
 QString GenomeComparison::access_genome(int row)
 {
 return genomeList[row]["genome"];

--- a/genomecomparison.ui
+++ b/genomecomparison.ui
@@ -6,14 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>744</width>
     <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="7,1,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,7,1,1">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Columns: 1-32 = coding genome; 1-64 = non-coding genome; E = environment colour; G = coding genome colour; N = non-coding genome colour; F = fitness.</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QTableWidget" name="genomeTableWidget">
      <property name="horizontalScrollBarPolicy">

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2006,6 +2006,7 @@ void MainWindow::on_actionSettings_triggered()
     } else
     {
         settings_dock->show();
+        settings_dock->raise();
         settingsButton->setChecked(true);
     }
 }
@@ -2016,10 +2017,11 @@ void MainWindow::orgSettings_triggered()
     if(org_settings_dock->isVisible())
     {
         org_settings_dock->hide();
-        orgSettingsButton->setChecked(false);
+        orgSettingsButton->setChecked(false);        
     } else
     {
         org_settings_dock->show();
+        org_settings_dock->raise();
         orgSettingsButton->setChecked(true);
     }
 }
@@ -2033,6 +2035,7 @@ void MainWindow::logSettings_triggered()
     } else
     {
         output_settings_dock->show();
+        output_settings_dock->raise();
         logSettingsButton->setChecked(true);
     }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -365,17 +365,20 @@ QDockWidget *MainWindow::createSimulationSettingsDock()
     // Environment Settings
     QGridLayout *environmentSettingsGrid = new QGridLayout;
 
-    QPushButton *changeEnvironmentFilesButton = new QPushButton("&Change Enviroment Files");
-    changeEnvironmentFilesButton->setObjectName("changeEnvironmentFilesButton");
-    environmentSettingsGrid->addWidget(changeEnvironmentFilesButton,0,1,1,2);
-    connect(changeEnvironmentFilesButton, SIGNAL (clicked()), this, SLOT(on_actionEnvironment_Files_triggered()));
-
     QLabel *environment_label= new QLabel("Environmental Settings");
     environment_label->setStyleSheet("font-weight: bold");
-    environmentSettingsGrid->addWidget(environment_label,1,1,1,2);
+    environmentSettingsGrid->addWidget(environment_label,0,1,1,2);
+
+    QPushButton *changeEnvironmentFilesButton = new QPushButton("&Change Enviroment Files");
+    changeEnvironmentFilesButton->setObjectName("changeEnvironmentFilesButton");
+    changeEnvironmentFilesButton->setToolTip("<font>REvoSim allow you to customise the enviroment by loading one or more image files.</font>");
+    environmentSettingsGrid->addWidget(changeEnvironmentFilesButton,1,1,1,2);
+    connect(changeEnvironmentFilesButton, SIGNAL (clicked()), this, SLOT(on_actionEnvironment_Files_triggered()));
 
     QLabel *environment_rate_label = new QLabel("Environment refresh rate:");
+    environment_rate_label->setToolTip("<font>This is the rate of change for the selected enviromental images.</font>");
     environment_rate_spin = new QSpinBox;
+    environment_rate_spin->setToolTip("<font>This is the rate of change for the selected enviromental images.</font>");
     environment_rate_spin->setMinimum(0);
     environment_rate_spin->setMaximum(100000);
     environment_rate_spin->setValue(envchangerate);
@@ -386,11 +389,16 @@ QDockWidget *MainWindow::createSimulationSettingsDock()
 
     QLabel *environment_mode_label = new QLabel("Environment mode:");
     environmentSettingsGrid->addWidget(environment_mode_label,3,1,1,2);
+
     QGridLayout *environmentModeGrid = new QGridLayout;
     environmentModeStaticButton = new QRadioButton("Static");
+    environmentModeStaticButton->setToolTip("<font>'Static' uses a single environment image.</font>");
     environmentModeOnceButton = new QRadioButton("Once");
+    environmentModeOnceButton->setToolTip("<font>'Once' uses each image only once, simulation stops after last image.</font>");
     environmentModeLoopButton = new QRadioButton("Loop");
+    environmentModeLoopButton->setToolTip("<font>'Loop' uses each image in order in a loop</font>");
     environmentModeBounceButton = new QRadioButton("Bounce");
+    environmentModeBounceButton->setToolTip("<font>'Bounce' rebounds between the first and last image in a loop.</font>");
     QButtonGroup* environmentModeButtonGroup = new QButtonGroup;
     environmentModeButtonGroup->addButton(environmentModeStaticButton,ENV_MODE_STATIC);
     environmentModeButtonGroup->addButton(environmentModeOnceButton,ENV_MODE_ONCE);
@@ -406,11 +414,13 @@ QDockWidget *MainWindow::createSimulationSettingsDock()
 
     interpolateCheckbox = new QCheckBox("Interpolate between images");
     interpolateCheckbox->setChecked(enviroment_interpolate);
+    interpolateCheckbox->setToolTip("<font>Turning this ON will iterpolate the environment between individual images.</font>");
     environmentSettingsGrid->addWidget(interpolateCheckbox,5,1,1,2);
     connect(interpolateCheckbox,&QCheckBox::stateChanged,[=](const bool &i) { enviroment_interpolate=i; });
 
     toroidal_checkbox = new QCheckBox("Toroidal enviroment");
     toroidal_checkbox->setChecked(toroidal);
+    toroidal_checkbox->setToolTip("<font>Turning this ON will allow dispersal of progeny in an unbounded warparound enviroment. Progeny leaving one side of the population window will immediately reappear on the opposite side.</font>");
     environmentSettingsGrid->addWidget(toroidal_checkbox,6,1,1,2);
     connect(toroidal_checkbox,&QCheckBox::stateChanged,[=](const bool &i) { toroidal=i; });
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -60,7 +60,6 @@ To do for paper:
 
 Coding:
 -- Load and Save don't include everything - they need to!
--- Genome comparison - say which is noncoding half / document
 -- Timer on calculting species - add progress bar and escape warning if needed to prevent crash
 -- Add Keyboard shortcuts where required
 -- Load and save settings still need to update gui

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -649,19 +649,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->fossRecDockContents->setLayout(frwLayout);
     ui->reportViewerDock->hide();
 
-    /*viewgroup = new QActionGroup(this);
-    // These actions were created via qt designer
-    viewgroup->addAction(ui->actionPopulation_Count);
-    viewgroup->addAction(ui->actionMean_fitness);
-    viewgroup->addAction(ui->actionGenome_as_colour);
-    viewgroup->addAction(ui->actionNonCoding_genome_as_colour);
-    viewgroup->addAction(ui->actionGene_Frequencies_012);
-    viewgroup->addAction(ui->actionSpecies);
-    viewgroup->addAction(ui->actionBreed_Fails_2);
-    viewgroup->addAction(ui->actionSettles);
-    viewgroup->addAction(ui->actionSettle_Fails);
-    QObject::connect(viewgroup, SIGNAL(triggered(QAction *)), this, SLOT(view_mode_changed(QAction *)));*/
-
     viewgroup2 = new QActionGroup(this);
     // These actions were created via qt designer
     viewgroup2->addAction(ui->actionNone);
@@ -711,7 +698,7 @@ MainWindow::MainWindow(QWidget *parent) :
     env_item->setPixmap(QPixmap::fromImage(*env_image));
     pop_item->setPixmap(QPixmap::fromImage(*pop_image));
 
-    //ARTS - population windows dropdown must be after settings dock setup
+    //ARTS - Population Window dropdown must be after settings dock setup
     // 0 = Population count
     // 1 = Mean fitnessFails (R-Breed, G=Settle)
     // 2 = Coding genome as colour
@@ -735,7 +722,7 @@ MainWindow::MainWindow(QWidget *parent) :
     //ui->populationWindowComboBox->addItem("Breed Fails 2",QVariant(9));
     ui->populationWindowComboBox->addItem("Species",QVariant(10));
 
-    // Set current index
+    //ARTS -Population Window dropdown set current index. Note this value is the index not the data value.
     ui->populationWindowComboBox->setCurrentIndex(2);
 
     TheSimManager = new SimManager;
@@ -1041,8 +1028,6 @@ void MainWindow::on_actionBatch_triggered()
     } else {
         return;
     }
-
-
 
     //ARTS - run the batch
     do {
@@ -1417,8 +1402,8 @@ void MainWindow::on_populationWindowComboBox_currentIndexChanged(int index)
     // 8 = Settle Fails
     // 9 = Breed Fails 2
     // 10 = Species
-
     int currentSelectedMode = ui->populationWindowComboBox->itemData(index).toInt();
+    Q_UNUSED(currentSelectedMode);
 
     //view_mode_changed();
     RefreshPopulations();
@@ -1427,15 +1412,14 @@ void MainWindow::on_populationWindowComboBox_currentIndexChanged(int index)
 void MainWindow::RefreshPopulations()
 //Refreshes of left window - also run species ident
 {
-
     //RJG - make path if required - this way as if user adds file name to path, this will create a subfolder with the same file name as logs
     QString save_path(path->text());
     if(!save_path.endsWith(QDir::separator()))save_path.append(QDir::separator());
     if(batch_running)
-        {
+    {
         save_path.append(QString("Images_run_%1").arg(runs, 4, 10, QChar('0')));
         save_path.append(QDir::separator());
-        }
+    }
     QDir save_dir(save_path);
 
     // 0 = Population count
@@ -1450,8 +1434,7 @@ void MainWindow::RefreshPopulations()
     // 9 = Breed Fails 2
     // 10 = Species
 
-    //check to see what the mode is
-
+    //ARTS - Check to see what the mode is from the Population Window QComboBox; return the data as int.
     int currentSelectedMode = ui->populationWindowComboBox->itemData(ui->populationWindowComboBox->currentIndex()).toInt();
 
     // (0) Population Count
@@ -1476,12 +1459,11 @@ void MainWindow::RefreshPopulations()
         //if (ui->actionPopulation_Count->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
         if (currentSelectedMode==0)pop_item->setPixmap(QPixmap::fromImage(*pop_image));
         if (save_population_count->isChecked())
-                 if(save_dir.mkpath("population/"))
-                             pop_image_colour->save(QString(save_dir.path()+"/population/EvoSim_population_it_%1.png").arg(generation, 7, 10, QChar('0')));
+            if(save_dir.mkpath("population/"))
+                pop_image_colour->save(QString(save_dir.path()+"/population/EvoSim_population_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
     // (1) Fitness
-    //if (ui->actionMean_fitness->isChecked()||save_mean_fitness->isChecked())
     if (currentSelectedMode==1||save_mean_fitness->isChecked())
     {
         //Popcount
@@ -1500,15 +1482,13 @@ void MainWindow::RefreshPopulations()
             pop_image->setPixel(n,m,(totalfit[n][m] * multiplier) / count);
 
         }
-        //if (ui->actionMean_fitness->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
         if (currentSelectedMode==1)pop_item->setPixmap(QPixmap::fromImage(*pop_image));
         if (save_mean_fitness->isChecked())
-                 if(save_dir.mkpath("fitness/"))
-                             pop_image_colour->save(QString(save_dir.path()+"/fitness/EvoSim_mean_fitness_it_%1.png").arg(generation, 7, 10, QChar('0')));
+            if(save_dir.mkpath("fitness/"))
+                pop_image_colour->save(QString(save_dir.path()+"/fitness/EvoSim_mean_fitness_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
     // (2) Genome as colour
-    //if (ui->actionGenome_as_colour->isChecked()||save_coding_genome_as_colour->isChecked())
     if (currentSelectedMode==2||save_coding_genome_as_colour->isChecked())
     {
         //find modal genome in each square, convert to colour
@@ -1572,15 +1552,13 @@ void MainWindow::RefreshPopulations()
 
        }
 
-       //if (ui->actionGenome_as_colour->isChecked()) pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
-       if (currentSelectedMode==2) pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
-       if (save_coding_genome_as_colour->isChecked())
-                if(save_dir.mkpath("coding/"))
-                            pop_image_colour->save(QString(save_dir.path()+"/coding/EvoSim_coding_genome_it_%1.png").arg(generation, 7, 10, QChar('0')));
+        if (currentSelectedMode==2) pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+        if (save_coding_genome_as_colour->isChecked())
+            if(save_dir.mkpath("coding/"))
+            pop_image_colour->save(QString(save_dir.path()+"/coding/EvoSim_coding_genome_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
     // (3) Non-coding Genome
-    //if (ui->actionNonCoding_genome_as_colour->isChecked()||save_non_coding_genome_as_colour->isChecked())
     if (currentSelectedMode==3||save_non_coding_genome_as_colour->isChecked())
     {
         //find modal genome in each square, convert non-coding to colour
@@ -1643,16 +1621,14 @@ void MainWindow::RefreshPopulations()
                 pop_image_colour->setPixel(n,m,qRgb(r, g, b));
             }
        }
-        //if(ui->actionNonCoding_genome_as_colour->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+
         if(currentSelectedMode==3)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
         if(save_non_coding_genome_as_colour->isChecked())
-                 if(save_dir.mkpath("non_coding/"))
-                             pop_image_colour->save(QString(save_dir.path()+"/non_coding/EvoSim_non_coding_it_%1.png").arg(generation, 7, 10, QChar('0')));
-
+            if(save_dir.mkpath("non_coding/"))
+                 pop_image_colour->save(QString(save_dir.path()+"/non_coding/EvoSim_non_coding_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
     // (4) Gene Frequencies
-    //if (ui->actionGene_Frequencies_012->isChecked()||save_gene_frequencies->isChecked())
     if (currentSelectedMode==4||save_gene_frequencies->isChecked())
     {
         //Popcount
@@ -1682,17 +1658,15 @@ void MainWindow::RefreshPopulations()
                 pop_image_colour->setPixel(n,m,qRgb(r, g, b));
             }
           }
-          //if (ui->actionGene_Frequencies_012->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
-          if (currentSelectedMode==4)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
-          if(save_gene_frequencies->isChecked())
-                 if(save_dir.mkpath("gene_freq/"))
-                             pop_image_colour->save(QString(save_dir.path()+"/gene_freq/EvoSim_gene_freq_it_%1.png").arg(generation, 7, 10, QChar('0')));
 
+        if (currentSelectedMode==4)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+        if(save_gene_frequencies->isChecked())
+            if(save_dir.mkpath("gene_freq/"))
+                pop_image_colour->save(QString(save_dir.path()+"/gene_freq/EvoSim_gene_freq_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
     // (5) Breed Attempts
     //RJG - No save option as no longer in the menu as an option.
-    //if (ui->actionBreed_Attempts->isChecked())
     if (currentSelectedMode==5)
     {
         //Popcount
@@ -1725,7 +1699,6 @@ void MainWindow::RefreshPopulations()
     }
 
     // (7) Settles
-    //if (ui->actionSettles->isChecked()||save_settles->isChecked())
     if (currentSelectedMode==7||save_settles->isChecked())
     {
         //Popcount
@@ -1737,17 +1710,14 @@ void MainWindow::RefreshPopulations()
             pop_image->setPixel(n,m,value);
         }
 
-       //if(ui->actionSettles->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
-       if(currentSelectedMode==7)pop_item->setPixmap(QPixmap::fromImage(*pop_image));
-       if(save_settles->isChecked())
-               if(save_dir.mkpath("settles/"))
-                           pop_image_colour->save(QString(save_dir.path()+"/settles/EvoSim_settles_it_%1.png").arg(generation, 7, 10, QChar('0')));
-
+        if(currentSelectedMode==7)pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+        if(save_settles->isChecked())
+            if(save_dir.mkpath("settles/"))
+                pop_image_colour->save(QString(save_dir.path()+"/settles/EvoSim_settles_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
     // (8) Settle Fails === Fails
-    //this now combines breed fails (red) and settle fails (green)
-    //if (ui->actionSettle_Fails->isChecked()||save_fails_settles->isChecked())
+    //RJG - this now combines breed fails (red) and settle fails (green)
     if (currentSelectedMode==8||save_fails_settles->isChecked())
     {
         //work out max and ratios
@@ -1778,16 +1748,15 @@ void MainWindow::RefreshPopulations()
             int g=ScaleFails(settlefails[n][m],gens);
             pop_image_colour->setPixel(n,m,qRgb(r, g, 0));
         }
-        //if(ui->actionSettle_Fails->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+
         if(currentSelectedMode==8)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
         if(save_fails_settles->isChecked())
-                if(save_dir.mkpath("settles_fails/"))
-                            pop_image_colour->save(QString(save_dir.path()+"/settles_fails/EvoSim_settles_fails_it_%1.png").arg(generation, 7, 10, QChar('0')));
+            if(save_dir.mkpath("settles_fails/"))
+                pop_image_colour->save(QString(save_dir.path()+"/settles_fails/EvoSim_settles_fails_it_%1.png").arg(generation, 7, 10, QChar('0')));
 
     }
 
     // (9) Breed Fails 2
-    //if (ui->actionBreed_Fails_2->isChecked())
     if (currentSelectedMode==9)
     {
         //Popcount
@@ -1806,7 +1775,6 @@ void MainWindow::RefreshPopulations()
     }
 
     // (10) Species
-    //if (ui->actionSpecies->isChecked()||save_species->isChecked()) //do visualisation if necessary
     if (currentSelectedMode==10||save_species->isChecked()) //do visualisation if necessary
     {
         for (int n=0; n<gridX; n++)
@@ -1829,11 +1797,11 @@ void MainWindow::RefreshPopulations()
                 pop_image_colour->setPixel(n,m,species_colours[thisspecies % 65536]);
             }
         }
-         //if (ui->actionSpecies->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+
         if (currentSelectedMode==10)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
-         if (save_species->isChecked())
-                  if(save_dir.mkpath("species/"))
-                              pop_image_colour->save(QString(save_dir.path()+"/species/EvoSim_species_it_%1.png").arg(generation, 7, 10, QChar('0')));
+        if (save_species->isChecked())
+            if(save_dir.mkpath("species/"))
+                pop_image_colour->save(QString(save_dir.path()+"/species/EvoSim_species_it_%1.png").arg(generation, 7, 10, QChar('0')));
 
     }
 
@@ -1859,7 +1827,8 @@ void MainWindow::RefreshEnvironment()
     env_item->setPixmap(QPixmap::fromImage(*env_image));
     if(save_environment->isChecked())
         if(save_dir.mkpath("environment/"))
-                    env_image->save(QString(save_dir.path()+"/environment/EvoSim_environment_it_%1.png").arg(generation, 7, 10, QChar('0')));
+            env_image->save(QString(save_dir.path()+"/environment/EvoSim_environment_it_%1.png").arg(generation, 7, 10, QChar('0')));
+
     //Draw on fossil records
     envscene->DrawLocations(FRW->FossilRecords,ui->actionShow_positions->isChecked());
 }
@@ -2031,44 +2000,41 @@ void MainWindow::redoImages(int oldrows, int oldcols)
 void MainWindow::on_actionSettings_triggered()
 {
     if(settings_dock->isVisible())
-        {
+    {
         settings_dock->hide();
         settingsButton->setChecked(false);
-        }
-    else
-        {
+    } else
+    {
         settings_dock->show();
         settingsButton->setChecked(true);
-        }
+    }
 }
 
 
 void MainWindow::orgSettings_triggered()
 {
     if(org_settings_dock->isVisible())
-        {
+    {
         org_settings_dock->hide();
         orgSettingsButton->setChecked(false);
-        }
-    else
-        {
+    } else
+    {
         org_settings_dock->show();
         orgSettingsButton->setChecked(true);
-        }
+    }
 }
 
 void MainWindow::logSettings_triggered()
 {
     if(output_settings_dock->isVisible())
-        {
+    {
         output_settings_dock->hide();
         logSettingsButton->setChecked(false);
-        }
-    else
-        {
+    } else
+    {
         output_settings_dock->show();
         logSettingsButton->setChecked(true);
-        }
+    }
 }
 
 
@@ -2150,12 +2116,10 @@ void MainWindow::on_actionChoose_Log_Directory_triggered()
 {
     QString dirname = QFileDialog::getExistingDirectory(this,"Select directory to log fossil record to");
 
-
     if (dirname.length()==0) return;
     FRW->LogDirectory=dirname;
     FRW->LogDirectoryChosen=true;
     FRW->HideWarnLabel();
-
 }
 
 //RJG - Fitness logging to file not sorted on save as yet.
@@ -2174,7 +2138,6 @@ void MainWindow::on_actionSave_triggered()
     outfile.open(QIODevice::WriteOnly|QIODevice::Text);
 
     QDataStream out(&outfile);
-
 
     out<<QString("EVOSIM file");
     out<<(int)FILEVERSION;
@@ -2370,7 +2333,6 @@ void MainWindow::on_actionLoad_triggered()
     if (filename.length()==0) return;
 
     if (stopflag==false) stopflag=true;
-
 
     //Otherwise - serialise all my crap
     QFile infile(filename);
@@ -2688,14 +2650,12 @@ void MainWindow::on_actionSet_Inactive_triggered()
 
 void MainWindow::on_actionSet_Sparsity_triggered()
 {
-
     bool ok;
 
     int value=QInputDialog::getInt(this,"","Sparsity",10,1,100000,1,&ok);
     if (!ok) return;
 
     FRW->SelectedSparse(value);
-
 }
 
 void MainWindow::on_actionShow_positions_triggered()
@@ -2768,7 +2728,6 @@ void MainWindow::CalcSpecies()
             lastSpeciesCalc=generation;
         }
         */
-
     }
 }
 
@@ -3135,7 +3094,6 @@ QString MainWindow::print_settings()
     settings_out<<"; Years per iteration: "<<yearsPerIteration;
     settings_out<<"; Minimum species size:"<<minspeciessize;
 
-
     settings_out<<". Bools - recalculate fitness: "<<recalcFitness;
     settings_out<<"; Toroidal environment: "<<toroidal;
     settings_out<<"; Nonspatial setling: "<<nonspatial;
@@ -3483,8 +3441,6 @@ void MainWindow::save_settings()
         settings_file.close();
 
        setStatusBarText("File saved");
-
-
 }
 
 //ARTS - Exit the application

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -688,7 +688,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->fossRecDockContents->setLayout(frwLayout);
     ui->reportViewerDock->hide();
 
-    viewgroup = new QActionGroup(this);
+    /*viewgroup = new QActionGroup(this);
     // These actions were created via qt designer
     viewgroup->addAction(ui->actionPopulation_Count);
     viewgroup->addAction(ui->actionMean_fitness);
@@ -699,7 +699,7 @@ MainWindow::MainWindow(QWidget *parent) :
     viewgroup->addAction(ui->actionBreed_Fails_2);
     viewgroup->addAction(ui->actionSettles);
     viewgroup->addAction(ui->actionSettle_Fails);
-    QObject::connect(viewgroup, SIGNAL(triggered(QAction *)), this, SLOT(view_mode_changed(QAction *)));
+    QObject::connect(viewgroup, SIGNAL(triggered(QAction *)), this, SLOT(view_mode_changed(QAction *)));*/
 
     viewgroup2 = new QActionGroup(this);
     // These actions were created via qt designer
@@ -749,6 +749,33 @@ MainWindow::MainWindow(QWidget *parent) :
 
     env_item->setPixmap(QPixmap::fromImage(*env_image));
     pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+
+    //ARTS - population windows dropdown must be after settings dock setup
+    // 0 = Population count
+    // 1 = Mean fitnessFails (R-Breed, G=Settle)
+    // 2 = Coding genome as colour
+    // 3 = NonCoding genome as colour
+    // 4 = Gene Frequencies
+    // 5 = Breed Attempts
+    // 6 = Breed Fails
+    // 7 = Settles
+    // 8 = Settle Fails
+    // 9 = Breed Fails 2
+    // 10 = Species
+    ui->populationWindowComboBox->addItem("Population count",QVariant(0));
+    ui->populationWindowComboBox->addItem("Mean fitnessFails (R-Breed, G=Settle)",QVariant(1));
+    ui->populationWindowComboBox->addItem("Coding genome as colour",QVariant(2));
+    ui->populationWindowComboBox->addItem("NonCoding genome as colour",QVariant(3));
+    ui->populationWindowComboBox->addItem("Gene Frequencies",QVariant(4));
+    //ui->populationWindowComboBox->addItem("Breed Attempts",QVariant(5));
+    //ui->populationWindowComboBox->addItem("Breed Fails",QVariant(6));
+    ui->populationWindowComboBox->addItem("Settles",QVariant(7));
+    ui->populationWindowComboBox->addItem("Settle Fails",QVariant(8));
+    //ui->populationWindowComboBox->addItem("Breed Fails 2",QVariant(9));
+    ui->populationWindowComboBox->addItem("Species",QVariant(10));
+
+    // Set current index
+    ui->populationWindowComboBox->setCurrentIndex(2);
 
     TheSimManager = new SimManager;
 
@@ -848,7 +875,7 @@ void MainWindow::on_actionReset_triggered()
 
     //ARTS - Update views based on the new reset simulation
     RefreshReport();
-    UpdateTitles();
+    //UpdateTitles();
     RefreshPopulations();
 }
 
@@ -1326,7 +1353,6 @@ void MainWindow::Report()
 
 void MainWindow::RefreshReport()
 {
-    UpdateTitles();
 
     QTime refreshtimer;
     refreshtimer.restart();
@@ -1404,43 +1430,6 @@ void MainWindow::RefreshReport()
 
 }
 
-void MainWindow::UpdateTitles()
-{
-    if (ui->actionPopulation_Count->isChecked())
-        ui->LabelVis->setText("Population Count");
-
-    if (ui->actionMean_fitness->isChecked())
-        ui->LabelVis->setText("Mean Fitness");
-
-
-    if (ui->actionGenome_as_colour->isChecked())
-        ui->LabelVis->setText("Coding Genome bitcount as colour (modal critter)");
-
-    if (ui->actionNonCoding_genome_as_colour->isChecked())
-        ui->LabelVis->setText("Non-Coding Genome bitcount as colour (modal critter)");
-
-    if (ui->actionSpecies->isChecked())
-        ui->LabelVis->setText("Species");
-
-    if (ui->actionGene_Frequencies_012->isChecked())
-        ui->LabelVis->setText("Frequences genes 0,1,2 (all critters in square)");
-
-    if (ui->actionBreed_Attempts->isChecked())
-        ui->LabelVis->setText("Breed Attempts");
-
-    if (ui->actionBreed_Fails->isChecked())
-        ui->LabelVis->setText("Breed Fails");
-
-    if (ui->actionSettles->isChecked())
-        ui->LabelVis->setText("Successful Settles");
-
-    if (ui->actionSettle_Fails->isChecked())
-        ui->LabelVis->setText("Breed Fails (red) and Settle Fails (green)");
-
-    if (ui->actionBreed_Fails_2->isChecked())
-        ui->LabelVis->setText("Breed Fails 2 (unused?)");
-}
-
 int MainWindow::ScaleFails(int fails, float gens)
 {
     //scale colour of fail count, correcting for generations, and scaling high values to something saner
@@ -1451,6 +1440,27 @@ int MainWindow::ScaleFails(int fails, float gens)
 
     if (ffails>255.0) ffails=255.0;
     return (int)ffails;
+}
+
+
+void MainWindow::on_populationWindowComboBox_currentIndexChanged(int index)
+{
+    // 0 = Population count
+    // 1 = Mean fitnessFails (R-Breed, G=Settle)
+    // 2 = Coding genome as colour
+    // 3 = NonCoding genome as colour
+    // 4 = Gene Frequencies
+    // 5 = Breed Attempts
+    // 6 = Breed Fails
+    // 7 = Settles
+    // 8 = Settle Fails
+    // 9 = Breed Fails 2
+    // 10 = Species
+
+    int currentSelectedMode = ui->populationWindowComboBox->itemData(index).toInt();
+
+    //view_mode_changed();
+    RefreshPopulations();
 }
 
 void MainWindow::RefreshPopulations()
@@ -1467,8 +1477,25 @@ void MainWindow::RefreshPopulations()
         }
     QDir save_dir(save_path);
 
+    // 0 = Population count
+    // 1 = Mean fitness
+    // 2 = Coding genome as colour
+    // 3 = NonCoding genome as colour
+    // 4 = Gene Frequencies
+    // 5 = Breed Attempts
+    // 6 = Breed Fails
+    // 7 = Settles
+    // 8 = Settle Fails === Fails (R-Breed, G=Settle)
+    // 9 = Breed Fails 2
+    // 10 = Species
+
     //check to see what the mode is
-    if (ui->actionPopulation_Count->isChecked()||save_population_count->isChecked())
+
+    int currentSelectedMode = ui->populationWindowComboBox->itemData(ui->populationWindowComboBox->currentIndex()).toInt();
+
+    // (0) Population Count
+    //if (ui->actionPopulation_Count->isChecked()||save_population_count->isChecked())
+    if (currentSelectedMode==0||save_population_count->isChecked())
     {
         //Popcount
         int bigcount=0;
@@ -1485,13 +1512,16 @@ void MainWindow::RefreshPopulations()
             if (count>255) count=255;
             pop_image->setPixel(n,m,count);
         }
-        if (ui->actionPopulation_Count->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+        //if (ui->actionPopulation_Count->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+        if (currentSelectedMode==0)pop_item->setPixmap(QPixmap::fromImage(*pop_image));
         if (save_population_count->isChecked())
                  if(save_dir.mkpath("population/"))
                              pop_image_colour->save(QString(save_dir.path()+"/population/EvoSim_population_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
-    if (ui->actionMean_fitness->isChecked()||save_mean_fitness->isChecked())
+    // (1) Fitness
+    //if (ui->actionMean_fitness->isChecked()||save_mean_fitness->isChecked())
+    if (currentSelectedMode==1||save_mean_fitness->isChecked())
     {
         //Popcount
         int multiplier=255/settleTolerance;
@@ -1509,13 +1539,16 @@ void MainWindow::RefreshPopulations()
             pop_image->setPixel(n,m,(totalfit[n][m] * multiplier) / count);
 
         }
-        if (ui->actionMean_fitness->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+        //if (ui->actionMean_fitness->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+        if (currentSelectedMode==1)pop_item->setPixmap(QPixmap::fromImage(*pop_image));
         if (save_mean_fitness->isChecked())
                  if(save_dir.mkpath("fitness/"))
                              pop_image_colour->save(QString(save_dir.path()+"/fitness/EvoSim_mean_fitness_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
-    if (ui->actionGenome_as_colour->isChecked()||save_coding_genome_as_colour->isChecked())
+    // (2) Genome as colour
+    //if (ui->actionGenome_as_colour->isChecked()||save_coding_genome_as_colour->isChecked())
+    if (currentSelectedMode==2||save_coding_genome_as_colour->isChecked())
     {
         //find modal genome in each square, convert to colour
         for (int n=0; n<gridX; n++)
@@ -1578,42 +1611,16 @@ void MainWindow::RefreshPopulations()
 
        }
 
-       if (ui->actionGenome_as_colour->isChecked()) pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+       //if (ui->actionGenome_as_colour->isChecked()) pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+       if (currentSelectedMode==2) pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
        if (save_coding_genome_as_colour->isChecked())
                 if(save_dir.mkpath("coding/"))
                             pop_image_colour->save(QString(save_dir.path()+"/coding/EvoSim_coding_genome_it_%1.png").arg(generation, 7, 10, QChar('0')));
     }
 
-    if (ui->actionSpecies->isChecked()||save_species->isChecked()) //do visualisation if necessary
-    {
-        for (int n=0; n<gridX; n++)
-        for (int m=0; m<gridY; m++)
-        {
-
-            if (totalfit[n][m]==0) pop_image_colour->setPixel(n,m,0); //black if square is empty
-            else
-            {
-                quint64 thisspecies=0;
-                for (int c=0; c<slotsPerSq; c++)
-                {
-                    if (critters[n][m][c].age>0)
-                    {
-                        thisspecies=critters[n][m][c].speciesid;
-                        break;
-                    }
-                }
-
-                pop_image_colour->setPixel(n,m,species_colours[thisspecies % 65536]);
-            }
-        }
-         if (ui->actionSpecies->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
-         if (save_species->isChecked())
-                  if(save_dir.mkpath("species/"))
-                              pop_image_colour->save(QString(save_dir.path()+"/species/EvoSim_species_it_%1.png").arg(generation, 7, 10, QChar('0')));
-
-    }
-
-    if (ui->actionNonCoding_genome_as_colour->isChecked()||save_non_coding_genome_as_colour->isChecked())
+    // (3) Non-coding Genome
+    //if (ui->actionNonCoding_genome_as_colour->isChecked()||save_non_coding_genome_as_colour->isChecked())
+    if (currentSelectedMode==3||save_non_coding_genome_as_colour->isChecked())
     {
         //find modal genome in each square, convert non-coding to colour
         for (int n=0; n<gridX; n++)
@@ -1675,14 +1682,17 @@ void MainWindow::RefreshPopulations()
                 pop_image_colour->setPixel(n,m,qRgb(r, g, b));
             }
        }
-        if(ui->actionNonCoding_genome_as_colour->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+        //if(ui->actionNonCoding_genome_as_colour->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+        if(currentSelectedMode==3)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
         if(save_non_coding_genome_as_colour->isChecked())
                  if(save_dir.mkpath("non_coding/"))
                              pop_image_colour->save(QString(save_dir.path()+"/non_coding/EvoSim_non_coding_it_%1.png").arg(generation, 7, 10, QChar('0')));
 
     }
 
-    if (ui->actionGene_Frequencies_012->isChecked()||save_gene_frequencies->isChecked())
+    // (4) Gene Frequencies
+    //if (ui->actionGene_Frequencies_012->isChecked()||save_gene_frequencies->isChecked())
+    if (currentSelectedMode==4||save_gene_frequencies->isChecked())
     {
         //Popcount
         for (int n=0; n<gridX; n++)
@@ -1711,15 +1721,18 @@ void MainWindow::RefreshPopulations()
                 pop_image_colour->setPixel(n,m,qRgb(r, g, b));
             }
           }
-          if (ui->actionGene_Frequencies_012->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+          //if (ui->actionGene_Frequencies_012->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+          if (currentSelectedMode==4)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
           if(save_gene_frequencies->isChecked())
                  if(save_dir.mkpath("gene_freq/"))
                              pop_image_colour->save(QString(save_dir.path()+"/gene_freq/EvoSim_gene_freq_it_%1.png").arg(generation, 7, 10, QChar('0')));
 
     }
 
+    // (5) Breed Attempts
     //RJG - No save option as no longer in the menu as an option.
-    if (ui->actionBreed_Attempts->isChecked())
+    //if (ui->actionBreed_Attempts->isChecked())
+    if (currentSelectedMode==5)
     {
         //Popcount
         for (int n=0; n<gridX; n++)
@@ -1732,8 +1745,9 @@ void MainWindow::RefreshPopulations()
         pop_item->setPixmap(QPixmap::fromImage(*pop_image));
     }
 
+    // (6) Breed Fails
     //RJG - No save option as no longer in the menu as an option.
-    if (ui->actionBreed_Fails->isChecked())
+    if (currentSelectedMode==6)
     {
         //Popcount
         for (int n=0; n<gridX; n++)
@@ -1749,7 +1763,9 @@ void MainWindow::RefreshPopulations()
         pop_item->setPixmap(QPixmap::fromImage(*pop_image));
     }
 
-    if (ui->actionSettles->isChecked()||save_settles->isChecked())
+    // (7) Settles
+    //if (ui->actionSettles->isChecked()||save_settles->isChecked())
+    if (currentSelectedMode==7||save_settles->isChecked())
     {
         //Popcount
         for (int n=0; n<gridX; n++)
@@ -1760,15 +1776,18 @@ void MainWindow::RefreshPopulations()
             pop_image->setPixel(n,m,value);
         }
 
-       if(ui->actionSettles->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+       //if(ui->actionSettles->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+       if(currentSelectedMode==7)pop_item->setPixmap(QPixmap::fromImage(*pop_image));
        if(save_settles->isChecked())
                if(save_dir.mkpath("settles/"))
                            pop_image_colour->save(QString(save_dir.path()+"/settles/EvoSim_settles_it_%1.png").arg(generation, 7, 10, QChar('0')));
 
     }
 
-    if (ui->actionSettle_Fails->isChecked()||save_fails_settles->isChecked())
+    // (8) Settle Fails === Fails
     //this now combines breed fails (red) and settle fails (green)
+    //if (ui->actionSettle_Fails->isChecked()||save_fails_settles->isChecked())
+    if (currentSelectedMode==8||save_fails_settles->isChecked())
     {
         //work out max and ratios
         /*int maxbf=1;
@@ -1798,14 +1817,17 @@ void MainWindow::RefreshPopulations()
             int g=ScaleFails(settlefails[n][m],gens);
             pop_image_colour->setPixel(n,m,qRgb(r, g, 0));
         }
-        if(ui->actionSettle_Fails->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+        //if(ui->actionSettle_Fails->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+        if(currentSelectedMode==8)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
         if(save_fails_settles->isChecked())
                 if(save_dir.mkpath("settles_fails/"))
                             pop_image_colour->save(QString(save_dir.path()+"/settles_fails/EvoSim_settles_fails_it_%1.png").arg(generation, 7, 10, QChar('0')));
 
     }
 
-    if (ui->actionBreed_Fails_2->isChecked())
+    // (9) Breed Fails 2
+    //if (ui->actionBreed_Fails_2->isChecked())
+    if (currentSelectedMode==9)
     {
         //Popcount
         for (int n=0; n<gridX; n++)
@@ -1820,6 +1842,38 @@ void MainWindow::RefreshPopulations()
             }
         }
         pop_item->setPixmap(QPixmap::fromImage(*pop_image));
+    }
+
+    // (10) Species
+    //if (ui->actionSpecies->isChecked()||save_species->isChecked()) //do visualisation if necessary
+    if (currentSelectedMode==10||save_species->isChecked()) //do visualisation if necessary
+    {
+        for (int n=0; n<gridX; n++)
+        for (int m=0; m<gridY; m++)
+        {
+
+            if (totalfit[n][m]==0) pop_image_colour->setPixel(n,m,0); //black if square is empty
+            else
+            {
+                quint64 thisspecies=0;
+                for (int c=0; c<slotsPerSq; c++)
+                {
+                    if (critters[n][m][c].age>0)
+                    {
+                        thisspecies=critters[n][m][c].speciesid;
+                        break;
+                    }
+                }
+
+                pop_image_colour->setPixel(n,m,species_colours[thisspecies % 65536]);
+            }
+        }
+         //if (ui->actionSpecies->isChecked())pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+        if (currentSelectedMode==10)pop_item->setPixmap(QPixmap::fromImage(*pop_image_colour));
+         if (save_species->isChecked())
+                  if(save_dir.mkpath("species/"))
+                              pop_image_colour->save(QString(save_dir.path()+"/species/EvoSim_species_it_%1.png").arg(generation, 7, 10, QChar('0')));
+
     }
 
     lastReport=generation;
@@ -1861,14 +1915,6 @@ void MainWindow::Resize()
     ui->GV_Population->fitInView(pop_item,Qt::KeepAspectRatio);
     ui->GV_Environment->fitInView(env_item,Qt::KeepAspectRatio);
 }
-
-//ARTS - action triggered to update the population window on view mode change
-void MainWindow::view_mode_changed(QAction * /* unused */)
-{
-    UpdateTitles();
-    RefreshPopulations();
-}
-
 
 void MainWindow::gui_checkbox_state_changed(bool dont_update)
 {
@@ -2199,17 +2245,7 @@ void MainWindow::on_actionSave_triggered()
     out<<emode;
 
     int vmode=0;
-    if (ui->actionPopulation_Count->isChecked()) vmode=0;
-    if (ui->actionMean_fitness->isChecked()) vmode=1;
-    if (ui->actionGenome_as_colour->isChecked()) vmode=2;
-    if (ui->actionNonCoding_genome_as_colour->isChecked()) vmode=3;
-    if (ui->actionGene_Frequencies_012->isChecked()) vmode=4;
-    if (ui->actionBreed_Attempts->isChecked()) vmode=5;
-    if (ui->actionBreed_Fails->isChecked()) vmode=6;
-    if (ui->actionSettles->isChecked()) vmode=7;
-    if (ui->actionSettle_Fails->isChecked()) vmode=8;
-    if (ui->actionBreed_Fails_2->isChecked()) vmode=9;
-    if (ui->actionSpecies->isChecked()) vmode=10;
+    vmode = ui->populationWindowComboBox->itemData(ui->populationWindowComboBox->currentIndex()).toInt();
 
     out<<vmode;
 
@@ -2418,19 +2454,23 @@ void MainWindow::on_actionLoad_triggered()
     if (emode==3) ui->actionBounce->setChecked(true);
     if (emode==2) ui->actionLoop->setChecked(true);
 
+    // 0 = Population count
+    // 1 = Mean fitnessFails (R-Breed, G=Settle)
+    // 2 = Coding genome as colour
+    // 3 = NonCoding genome as colour
+    // 4 = Gene Frequencies
+    // 5 = Breed Attempts
+    // 6 = Breed Fails
+    // 7 = Settles
+    // 8 = Settle Fails
+    // 9 = Breed Fails 2
+    // 10 = Species
     int vmode;
     in>>vmode;
-    if (vmode==0) ui->actionPopulation_Count->setChecked(true);
-    if (vmode==1) ui->actionMean_fitness->setChecked(true);
-    if (vmode==2) ui->actionGenome_as_colour->setChecked(true);
-    if (vmode==3) ui->actionNonCoding_genome_as_colour->setChecked(true);
-    if (vmode==4) ui->actionGene_Frequencies_012->setChecked(true);
-    if (vmode==5) ui->actionBreed_Attempts->setChecked(true);
-    if (vmode==6) ui->actionBreed_Fails->setChecked(true);
-    if (vmode==7) ui->actionSettles->setChecked(true);
-    if (vmode==8) ui->actionSettle_Fails->setChecked(true);
-    if (vmode==9) ui->actionBreed_Fails_2->setChecked(true);
-    if (vmode==10) ui->actionSpecies->setChecked(true);
+    int index = ui->populationWindowComboBox->findData(vmode);
+    if ( index != -1 ) { // -1 for not found
+       ui->populationWindowComboBox->setCurrentIndex(index);
+    }
 
     int rmode;
     in>>rmode;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -115,7 +115,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ResizeCatcher *rescatch = new ResizeCatcher(this);
     ui->centralWidget->installEventFilter(rescatch);
 
-
     //ARTS - Toolbar buttons
     //RJG - docker toggles
     startButton = new QAction(QIcon(QPixmap(":/toolbar/startButton-Enabled.png")), QString("Run"), this);
@@ -203,6 +202,8 @@ MainWindow::MainWindow(QWidget *parent) :
     //RJG - Make docks tabbed
     tabifyDockWidget(organismSettingsDock,simulationSettingsDock);
     tabifyDockWidget(simulationSettingsDock,outputSettingsDock);
+
+    //ARST - Hide docks by default
     organismSettingsDock->hide();
     simulationSettingsDock->hide();
     outputSettingsDock->hide();
@@ -339,15 +340,15 @@ MainWindow::MainWindow(QWidget *parent) :
     //Then scaled to zero to 32 bit rand max, to allow for probabilities within each iteration through a random number
     float x=-3., inc=(6./32.);
     for(int cnt=0;cnt<33;cnt++)
-            {
-            double NSDF=(0.5 * erfc(-(x) * M_SQRT1_2));
-            cumulative_normal_distribution[cnt]=4294967296*NSDF;
-            x+=inc;
-            }
+    {
+        double NSDF=(0.5 * erfc(-(x) * M_SQRT1_2));
+        cumulative_normal_distribution[cnt]=4294967296*NSDF;
+        x+=inc;
+    }
 
     //RJG - fill pathogen probability distribution as required so pathogens can kill critters
     //Start with linear, may want to change down the line.
-      for(int cnt=0;cnt<65;cnt++)
+    for(int cnt=0;cnt<65;cnt++)
         pathogen_prob_distribution[cnt]=(4294967296/2)+(cnt*(4294967295/128));
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -69,7 +69,6 @@ private:
     void RunSetUp();
     void FinishRun();
     void RefreshPopulations();
-    void UpdateTitles();
     void resetInformationBar();
 
     //RJG - some imporant variables
@@ -129,7 +128,6 @@ private slots:
     void logSettings_triggered();
     void on_actionCount_Peaks_triggered();
     void on_actionMisc_triggered();
-    void view_mode_changed(QAction *);
     void report_mode_changed(QAction *);
     void gui_checkbox_state_changed(bool);
     void save_all_checkbox_state_changed(bool);
@@ -160,6 +158,7 @@ private slots:
     void changepath_triggered();
     void on_actionAbout_triggered();
     void on_actionExit_triggered();
+    void on_populationWindowComboBox_currentIndexChanged(int index);
 };
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -46,8 +46,6 @@ public:
     MainWindow(QWidget *parent = 0);
     ~MainWindow();
     FossRecWidget *FRW;
-
-    //---- ARTS: Add Genome Comparison UI
     GenomeComparison *genoneComparison;
     bool genomeComparisonAdd();
     void RefreshReport();
@@ -60,15 +58,6 @@ public:
     QDockWidget* createOrganismSettingsDock();
 
     int RefreshRate;
-
-    //If you want to have Max/Min/Close buttons, look at how QWinWidget uses these
-    QPushButton* maximizeButton = nullptr;
-    QPushButton* minimizeButton = nullptr;
-    QPushButton* closeButton = nullptr;
-
-    //If you want to enable dragging the window when the mouse is over top of, say, a QToolBar,
-    //then look at how QWinWidget uses this
-    QToolBar* toolBar = nullptr;
 
 protected:
     void changeEvent(QEvent *e);
@@ -85,27 +74,24 @@ private:
 
     //RJG - some imporant variables
     bool stopflag;
-
     bool pauseflag;
     int waitUntilPauseSignalIsEmitted();
-
     int NextRefresh;
 
     //RJG - GUI stuff
     EnvironmentScene *envscene;
     PopulationScene *popscene;
-    QActionGroup *viewgroup, *viewgroup2, *speciesgroup;
-    QActionGroup *envgroup;
+    QActionGroup *viewgroup2;
     QDockWidget *simulationSettingsDock, *organismSettingsDock, *outputSettingsDock;
 
     //RJG - GUI buttons and settings docker options which need to be accessible via slots, especially for load settings function
     QAction *startButton, *stopButton, *pauseButton, *runForButton, *resetButton, *reseedButton, *runForBatchButton, *settingsButton, *orgSettingsButton, *logSettingsButton, *aboutButton;
     //RJG - Save images checkboxes
-    QCheckBox *gui_checkbox, *save_population_count, *save_mean_fitness, *save_coding_genome_as_colour, *save_species, *save_non_coding_genome_as_colour, *save_gene_frequencies, *save_settles, *save_fails_settles, *save_environment;
-   //RJG - other checkboxes
+    QCheckBox *gui_checkbox, *save_population_count, *save_mean_fitness, *save_coding_genome_as_colour, *save_species, *save_non_coding_genome_as_colour, *save_gene_frequencies, *save_settles, *save_fails_settles, *save_environment, *interpolateCheckbox;
+    //RJG - other checkboxes
     QCheckBox *recalcFitness_checkbox, *toroidal_checkbox, *nonspatial_checkbox, *breeddiff_checkbox, *breedspecies_checkbox, *pathogens_checkbox, *variable_mutation_checkbox, *exclude_without_issue_checkbox, *logging_checkbox, *autodump_checkbox;
     //RJG - radios and spins
-    QRadioButton *phylogeny_off_button, *basic_phylogeny_button, *phylogeny_button, *phylogeny_and_metrics_button, *sexual_radio, *asexual_radio, *variableBreed_radio;
+    QRadioButton *phylogeny_off_button, *basic_phylogeny_button, *phylogeny_button, *phylogeny_and_metrics_button, *sexual_radio, *asexual_radio, *variableBreed_radio, *environmentModeBounceButton, *environmentModeLoopButton, *environmentModeOnceButton, *environmentModeStaticButton;
     QSpinBox *mutate_spin, *refreshRateSpin, *pathogen_mutate_spin, *pathogen_frequency_spin , *maxDiff_spin, *breedThreshold_spin, *target_spin , *environment_rate_spin, *gridX_spin , *gridY_spin, *settleTolerance_spin, *slots_spin, *startAge_spin, *dispersal_spin, *energy_spin, *breedCost_spin;
     //RJG - global save path for all outputs
     QLineEdit *path;
@@ -165,6 +151,7 @@ private slots:
     void on_actionLoad_Random_Numbers_triggered();
     void on_SelectLogFile_pressed();
     void species_mode_changed(int change_species_mode);
+    void environment_mode_changed(int change_environment_mode);
     void on_actionGenerate_NWK_tree_file_triggered();
     void on_actionSpecies_sizes_triggered();
     void changepath_triggered();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -55,6 +55,9 @@ public:
     void RefreshEnvironment();
     void setStatusBarText(QString text);
     Ui::MainWindow *ui;
+    QDockWidget* createSimulationSettingsDock();
+    QDockWidget* createOutputSettingsDock();
+    QDockWidget* createOrganismSettingsDock();
 
     int RefreshRate;
 
@@ -93,7 +96,7 @@ private:
     PopulationScene *popscene;
     QActionGroup *viewgroup, *viewgroup2, *speciesgroup;
     QActionGroup *envgroup;
-    QDockWidget *settings_dock, *org_settings_dock, *output_settings_dock;
+    QDockWidget *simulationSettingsDock, *organismSettingsDock, *outputSettingsDock;
 
     //RJG - GUI buttons and settings docker options which need to be accessible via slots, especially for load settings function
     QAction *startButton, *stopButton, *pauseButton, *runForButton, *resetButton, *reseedButton, *runForBatchButton, *settingsButton, *orgSettingsButton, *logSettingsButton, *aboutButton;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1349,7 +1349,7 @@ p, li { white-space: pre-wrap; }
   </action>
   <action name="actionReseed">
    <property name="checkable">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <property name="text">
     <string>Reseed with known genome...</string>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -137,12 +137,15 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="LabelVis">
-              <property name="text">
-               <string> Coding Genome</string>
+             <widget class="QComboBox" name="populationWindowComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              <property name="currentIndex">
+               <number>-1</number>
               </property>
              </widget>
             </item>
@@ -800,7 +803,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>1220</width>
-     <height>23</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuCommands">
@@ -831,22 +834,6 @@ p, li { white-space: pre-wrap; }
     <addaction name="actionCount_peaks"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
-   </widget>
-   <widget class="QMenu" name="menuView">
-    <property name="title">
-     <string>Visualisation</string>
-    </property>
-    <addaction name="actionPopulation_Count"/>
-    <addaction name="actionMean_fitness"/>
-    <addaction name="actionGenome_as_colour"/>
-    <addaction name="actionNonCoding_genome_as_colour"/>
-    <addaction name="actionGene_Frequencies_012"/>
-    <addaction name="actionBreed_Attempts"/>
-    <addaction name="actionBreed_Fails"/>
-    <addaction name="actionSettle_Fails"/>
-    <addaction name="actionSettles"/>
-    <addaction name="actionSpecies"/>
-    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuEnvironment">
     <property name="title">
@@ -918,7 +905,6 @@ p, li { white-space: pre-wrap; }
    </widget>
    <addaction name="menuCommands"/>
    <addaction name="menuEnvironment"/>
-   <addaction name="menuView"/>
    <addaction name="menuFossil_Record"/>
    <addaction name="menuDocks"/>
    <addaction name="menuAnalysis_Tools"/>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -826,19 +826,6 @@ p, li { white-space: pre-wrap; }
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
-   <widget class="QMenu" name="menuEnvironment">
-    <property name="title">
-     <string>Environment</string>
-    </property>
-    <addaction name="actionStatic"/>
-    <addaction name="actionOnce"/>
-    <addaction name="actionLoop"/>
-    <addaction name="actionBounce"/>
-    <addaction name="separator"/>
-    <addaction name="actionInterpolate"/>
-    <addaction name="separator"/>
-    <addaction name="actionEnvironment_Files"/>
-   </widget>
    <widget class="QMenu" name="menuDocks">
     <property name="title">
      <string>Genome Comparison</string>
@@ -895,7 +882,6 @@ p, li { white-space: pre-wrap; }
     <addaction name="actionAbout"/>
    </widget>
    <addaction name="menuCommands"/>
-   <addaction name="menuEnvironment"/>
    <addaction name="menuFossil_Record"/>
    <addaction name="menuDocks"/>
    <addaction name="menuAnalysis_Tools"/>
@@ -1152,41 +1138,6 @@ p, li { white-space: pre-wrap; }
     <string>Ctrl+O</string>
    </property>
   </action>
-  <action name="actionLoop">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Loop</string>
-   </property>
-  </action>
-  <action name="actionBounce">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Bounce</string>
-   </property>
-  </action>
-  <action name="actionOnce">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Once</string>
-   </property>
-  </action>
-  <action name="actionStatic">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Static</string>
-   </property>
-  </action>
   <action name="actionInformation">
    <property name="checkable">
     <bool>true</bool>
@@ -1291,17 +1242,6 @@ p, li { white-space: pre-wrap; }
   <action name="actionSet_Inactive">
    <property name="text">
     <string>Set Inactive</string>
-   </property>
-  </action>
-  <action name="actionInterpolate">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Interpolate</string>
    </property>
   </action>
   <action name="actionSpecies">

--- a/populationscene.cpp
+++ b/populationscene.cpp
@@ -64,7 +64,7 @@ void PopulationScene::mouseMoveEvent(QGraphicsSceneMouseEvent * event)
 }
 
 
-void PopulationScene::mousePressEvent(QGraphicsSceneMouseEvent * event )
+void PopulationScene::mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
     QPointF position=event->scenePos();
     int x,y;
@@ -80,8 +80,10 @@ void PopulationScene::mousePressEvent(QGraphicsSceneMouseEvent * event )
     return;
 }
 
-void PopulationScene::mouseReleaseEvent ( QGraphicsSceneMouseEvent * event )
+void PopulationScene::mouseReleaseEvent (QGraphicsSceneMouseEvent * event)
 {
+    Q_UNUSED(event);
+
     //don't do anything
     return;
 }

--- a/simmanager.cpp
+++ b/simmanager.cpp
@@ -73,6 +73,7 @@ bool sexual=true;
 bool logging=false;
 bool fitnessLoggingToFile=false;
 bool nonspatial=false;
+bool enviroment_interpolate=true;
 bool toroidal=false;
 bool reseedKnown=false;
 bool reseedDual=false;
@@ -128,6 +129,9 @@ QList<uint> species_colours;
 quint8 species_mode;
 quint64 ids; //used in tree export -
 
+// Enviroment Stuff
+quint8 environment_mode;
+
 quint64 minspeciessize;
 bool allowexcludewithissue;
 
@@ -138,6 +142,8 @@ SimManager::SimManager()
 {
     //Constructor - set up all the data!
     species_mode=SPECIES_MODE_BASIC;
+    environment_mode=ENV_MODE_LOOP;
+    enviroment_interpolate = true;
     MakeLookups();
     AliveCount=0;
     ProcessorCount=QThread::idealThreadCount();

--- a/simmanager.h
+++ b/simmanager.h
@@ -166,6 +166,13 @@ extern quint8 species_mode;
 #define SPECIES_MODE_PHYLOGENY 2
 #define SPECIES_MODE_PHYLOGENY_AND_METRICS 3
 
+extern quint8 environment_mode;
+#define ENV_MODE_STATIC 0
+#define ENV_MODE_ONCE 1
+#define ENV_MODE_LOOP 2
+#define ENV_MODE_BOUNCE 3
+extern bool enviroment_interpolate;
+
 extern quint64 minspeciessize;
 extern bool allowexcludewithissue;
 extern quint64 ids;


### PR DESCRIPTION
1) Visualisation main menu has been removed, and replaced by a QComboBox widget in the header of the Population window. This change has allowed the remove of various associated functions, e.g. UpdateTitles, ... as the QComboBox acts as the title text.

2) Added code to set the focus on the last opened settings dock - so that on on pressing a settings button to open the desired dock it does not appear behind already opened docks.

3) Added description to genome dock for column headers.

4) Moved the setting docks out of the MainWindow constructor to their own functions. Improves code re-ability.

5) Reduced the number of compiler warnings by implementing the use of Q_UNUSED() where possible.

6) Removed the Environment submenu from the main menu. These settings are now found in the Simulation Settings dock.

7) Added some QToolTip text hints to the Environment settings under the Simulation Settings Dock. Just to see if this works better than the green text used in the Output Setting Dock.

8) Changed the Reseed menu item to be non-checkable. I can't see why this checkable to start with.